### PR TITLE
City of Mist Status & Tags Tracker

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -18,11 +18,18 @@
 
 "CityOfMistTracker.trackerwindow.title": "City of Mist Status Tracker",
 "CityOfMistTracker.trackerwindow.empty": "Place a token on the scene to start the tracker.",
-"CityOfMistTracker.trackerwindow.statuses": "Statuses",
+"CityOfMistTracker.trackerwindow.statuses": "Statuses & Tags",
 "CityOfMistTracker.trackerwindow.status.addto": "Add tier to status",
 "CityOfMistTracker.trackerwindow.status.subtract": "Subtract tier from status",
 "CityOfMistTracker.trackerwindow.status.addnew": "Add a new status",
 "CityOfMistTracker.trackerwindow.status.permanent": "Permanent status",
 "CityOfMistTracker.trackerwindow.status.temporary": "Temporary status",
-"CityOfMistTracker.trackerwindow.status.delete": "Delete status"
+"CityOfMistTracker.trackerwindow.status.delete": "Delete status",
+
+"CityOfMistTracker.trackerwindow.tag.addnew": "Add a new story tag",
+"CityOfMistTracker.trackerwindow.tag.permanent": "Permanent Tag",
+"CityOfMistTracker.trackerwindow.tag.temporary": "Temporary Tag",
+"CityOfMistTracker.trackerwindow.tag.delete": "Delete story tag",
+"CityOfMistTracker.trackerwindow.tag.storytag": "Story Tag",
+"CityOfMistTracker.trackerwindow.tag.burned": "Burn tag"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -14,5 +14,15 @@
 "ITEM.TypeJuice" : "Juice",
 "ITEM.TypeMove" : "Player Move",
 "ITEM.TypeGmmove" : "MC Move",
-"ITEM.TypeSpectrum" : "Danger Spectrum"
+"ITEM.TypeSpectrum" : "Danger Spectrum",
+
+"CityOfMistTracker.trackerwindow.title": "City of Mist Status Tracker",
+"CityOfMistTracker.trackerwindow.empty": "Place a token on the scene to start the tracker.",
+"CityOfMistTracker.trackerwindow.statuses": "Statuses",
+"CityOfMistTracker.trackerwindow.status.addto": "Add tier to status",
+"CityOfMistTracker.trackerwindow.status.subtract": "Subtract tier from status",
+"CityOfMistTracker.trackerwindow.status.addnew": "Add a new status",
+"CityOfMistTracker.trackerwindow.status.permanent": "Permanent status",
+"CityOfMistTracker.trackerwindow.status.temporary": "Temporary status",
+"CityOfMistTracker.trackerwindow.status.delete": "Delete status"
 }

--- a/module/city-status-tracker/city-status-tracker.css
+++ b/module/city-status-tracker/city-status-tracker.css
@@ -1,0 +1,27 @@
+.status-block {
+  text-align: center;
+}
+
+span.status-actor {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+#city-status-tracker-list ol {
+  width: 100%;
+}
+
+#city-status-tracker-list li{
+  list-style-type: none;
+  margin-left: -10%;
+}
+
+#city-status-tracker-list .status-control {
+  flex: 0;
+  margin: 4px;
+}
+
+#city-status-tracker-list .status-type {
+  flex: 0;
+  margin: 0px;
+}

--- a/module/city-status-tracker/city-status-tracker.css
+++ b/module/city-status-tracker/city-status-tracker.css
@@ -5,10 +5,16 @@
 span.status-actor {
   font-weight: bold;
   text-decoration: underline;
+  margin: 6px;
+}
+
+span.status-description {
+  padding: 4px 0px;
 }
 
 #city-status-tracker-list ol {
   width: 100%;
+  margin: 0px;
 }
 
 #city-status-tracker-list li{
@@ -24,4 +30,23 @@ span.status-actor {
 #city-status-tracker-list .status-type {
   flex: 0;
   margin: 0px;
+}
+
+#city-status-tracker-list .tag-control {
+  flex: 0;
+  margin: 4px;
+}
+
+#city-status-tracker-list .tag-type {
+  flex: 0;
+  margin: 0px;
+}
+
+#city-status-tracker-list .tag-burn {
+  flex: 0;
+  margin: 4px 15px 4px 15px;
+}
+
+#city-status-tracker-list .tag-burned {
+  color: var(--neon-pink);
 }

--- a/module/city-status-tracker/city-status-tracker.hbs
+++ b/module/city-status-tracker/city-status-tracker.hbs
@@ -1,0 +1,38 @@
+<div class="city-status-tracker">
+  <div class="status-text-list-header"> 
+    {{ localize "CityOfMistTracker.trackerwindow.statuses"}}
+	</div>
+  
+  {{#if statusTracker.actors }}
+    {{#each statusTracker.actors as |actor indexActor| }}
+      <div class="status-block">
+        <span class="status-actor"> {{actor.name}} </span>
+        <a class="status-control status-add" title="{{ localize "CityOfMistTracker.trackerwindow.status.addnew" }}" data-actor="{{ @indexActor }}" data-action="status-new"><i class="fas fa-plus"></i></a>
+        <ol id="city-status-tracker-list">
+        {{#each actor.statuses as |status indexStatus|}}
+          <li>
+            <div class="flexrow">
+              <a class="status-control status-delete" title="{{ localize "CityOfMistTracker.trackerwindow.status.delete" }}" data-actor="{{ @indexActor }}" data-status="{{ @indexStatus }}" data-action="status-delete"><i class="fas fa-trash"></i></a>
+              <span class="status-description">
+                {{#if  status.data.data.temporary}}
+                  <a class="status-type" title="{{ localize "CityOfMistTracker.trackerwindow.status.temporary" }}" ><i class="fas fa-hourglass"></i> </a>
+                {{/if}}
+                {{#if  status.data.data.permanent}}
+                  <a class="status-type" title="{{ localize "CityOfMistTracker.trackerwindow.status.permanent" }}" ><i class="fas fa-square"></i> </a>
+                {{/if}}
+                {{status.name}}-{{status.data.data.tier}}
+              </span>
+              <a class="status-control status-increase" title="{{ localize "CityOfMistTracker.trackerwindow.status.addto" }}"  data-actor="{{ @indexActor }}" data-status="{{ @indexStatus }}" data-action="status-increase"><i class="fas fa-plus"></i></a>
+              <a class="status-control status-decrease" title="{{ localize "CityOfMistTracker.trackerwindow.status.subtract" }}"  data-actor="{{ @indexActor }}" data-status="{{ @indexStatus }}" data-action="status-decrease"><i class="fas fa-minus"></i></a>
+            </div>
+          </li>
+        {{/each}}
+        </ol>
+      </div>
+    {{/each}}
+  {{else}}
+    <p>
+      {{ localize "CityOfMistTracker.trackerwindow.empty" }}
+    </p>
+  {{/if}}
+</div>  

--- a/module/city-status-tracker/city-status-tracker.hbs
+++ b/module/city-status-tracker/city-status-tracker.hbs
@@ -7,7 +7,8 @@
     {{#each statusTracker.actors as |actor indexActor| }}
       <div class="status-block">
         <span class="status-actor"> {{actor.name}} </span>
-        <a class="status-control status-add" title="{{ localize "CityOfMistTracker.trackerwindow.status.addnew" }}" data-actor="{{ @indexActor }}" data-action="status-new"><i class="fas fa-plus"></i></a>
+        <a class="status-control status-add" title="{{ localize "CityOfMistTracker.trackerwindow.status.addnew" }}" data-actor="{{ @indexActor }}" data-action="status-new"><i class="fas fa-plus-square"></i></a>
+        <a class="status-control tag-add" title="{{ localize "CityOfMistTracker.trackerwindow.tag.addnew" }}" data-actor="{{ @indexActor }}" data-action="tag-new"><i class="fas fa-tag"></i></a>
         <ol id="city-status-tracker-list">
         {{#each actor.statuses as |status indexStatus|}}
           <li>
@@ -24,6 +25,26 @@
               </span>
               <a class="status-control status-increase" title="{{ localize "CityOfMistTracker.trackerwindow.status.addto" }}"  data-actor="{{ @indexActor }}" data-status="{{ @indexStatus }}" data-action="status-increase"><i class="fas fa-plus"></i></a>
               <a class="status-control status-decrease" title="{{ localize "CityOfMistTracker.trackerwindow.status.subtract" }}"  data-actor="{{ @indexActor }}" data-status="{{ @indexStatus }}" data-action="status-decrease"><i class="fas fa-minus"></i></a>
+            </div>
+          </li>
+        {{/each}}
+        </ol>
+        <ol id="city-status-tracker-list">
+        {{#each actor.tags as |tag indexTag|}}
+          <li>
+            <div class="flexrow">
+              <a class="status-control tag-delete" title="{{ localize "CityOfMistTracker.trackerwindow.tag.delete" }}" data-actor="{{ @indexActor }}" data-tag="{{ @indexTag }}" data-action="tag-delete"><i class="fas fa-trash"></i></a>
+              <span class="status-description">
+                <a class="tag-type" title="{{ localize "CityOfMistTracker.trackerwindow.tag.storytag" }}" ><i class="fas fa-tag"></i> </a>
+                {{#if  tag.data.data.temporary}}
+                  <a class="tag-type" title="{{ localize "CityOfMistTracker.trackerwindow.tag.temporary" }}" ><i class="fas fa-hourglass"></i> </a>
+                {{/if}}
+                {{#if  tag.data.data.permanent}}
+                  <a class="tag-type" title="{{ localize "CityOfMistTracker.trackerwindow.tag.permanent" }}" ><i class="fas fa-square"></i> </a>
+                {{/if}}
+                {{tag.name}}
+              </span>
+              <a class="tag-burn {{#if tag.data.data.burned }} tag-burned {{/if}}" title="{{ localize "CityOfMistTracker.trackerwindow.tag.burned" }}" ><i class="fas fa-fire"></i> </a>
             </div>
           </li>
         {{/each}}

--- a/module/city-status-tracker/city-status-tracker.js
+++ b/module/city-status-tracker/city-status-tracker.js
@@ -1,0 +1,101 @@
+/* global jQuery, Handlebars, Sortable */
+/* global game, loadTemplates, mergeObject, Application, FormApplication, Dialog */
+
+import { StatusTracker } from "./status-tracker.js";
+
+Hooks.on('updateActor', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('updateItem', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('createItem', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('deleteItem', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('deleteActor', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('createToken', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('updateToken', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('deleteToken', function() {window.statusTrackerWindow.render(false)});
+Hooks.on('updateScene', function() {window.statusTrackerWindow.render(false)});
+
+export class StatusTrackerWindow extends Application {
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      id: "city-of-mist-tracker-app",
+      template: "systems/city-of-mist/module/city-status-tracker/city-status-tracker.hbs",
+      width: 315,
+      height: 630,
+      minimizable: true,
+      resizable: true,
+      title: game.i18n.localize("CityOfMistTracker.trackerwindow.title"),
+    });
+  }
+
+  /**
+   * Set up interactivity for the window.
+   *
+   * @param {JQuery} html is the rendered HTML provided by jQuery
+   **/
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    html.on("click", "a.status-control", async function () {
+      const indexStatus = jQuery(this).data("status");
+      const indexActor = jQuery(this).data("actor");
+      const action = jQuery(this).data("action");
+
+      const tracker = window.statusTrackerWindow.getData().statusTracker;
+
+      switch (action) {
+        case "status-new":
+          await tracker.newStatus(indexActor);
+          break;
+        case "status-delete":
+          await tracker.deleteStatus(indexActor, indexStatus);
+          break;
+        case "status-increase":
+          await tracker.increaseStatus(indexActor, indexStatus);
+          break;
+        case "status-decrease":
+          await tracker.decreaseStatus(indexActor, indexStatus);
+          break;
+        default:
+          return;
+      }
+
+      window.statusTrackerWindow.render(false);
+    });
+
+    /*html.on("dblclick", "p.aspect-description", async function () {
+      const index = jQuery(this).data("index");
+
+      const list = window.aspectTrackerWindow.getData().tracker;
+
+      await list.toggleEditing(index);
+
+      window.aspectTrackerWindow.render(true);
+    });
+
+    html.on("keypress", "p.edit-description", async function(e){
+      if(e.which === 13){
+        const index = jQuery(this).data("index");
+        const desc = jQuery(this).children().get(0).value;
+
+        const list = window.aspectTrackerWindow.getData().tracker;
+
+        let aspect = list.aspects[index];
+        aspect.description = desc;
+
+        await list.updateAspect(index, aspect);
+        await list.toggleEditing(index);
+
+        window.aspectTrackerWindow.render(true);
+      }
+   });*/
+  }
+
+  /**
+   * @returns {StatusTracker}
+   * @returns {boolean}
+   */
+  getData() {
+    return {
+      statusTracker: StatusTracker.load()
+    };
+  }
+}

--- a/module/city-status-tracker/city-status-tracker.js
+++ b/module/city-status-tracker/city-status-tracker.js
@@ -36,6 +36,7 @@ export class StatusTrackerWindow extends Application {
 
     html.on("click", "a.status-control", async function () {
       const indexStatus = jQuery(this).data("status");
+      const indexTag = jQuery(this).data("tag");
       const indexActor = jQuery(this).data("actor");
       const action = jQuery(this).data("action");
 
@@ -54,6 +55,12 @@ export class StatusTrackerWindow extends Application {
         case "status-decrease":
           await tracker.decreaseStatus(indexActor, indexStatus);
           break;
+        case "tag-new":
+          await tracker.newTag(indexActor);
+          break;
+        case "tag-delete":
+          await tracker.deleteTag(indexActor, indexTag);
+          break
         default:
           return;
       }

--- a/module/city-status-tracker/status-tracker.js
+++ b/module/city-status-tracker/status-tracker.js
@@ -1,0 +1,129 @@
+import { CityHelpers } from "../city-helpers.js";
+
+export class StatusTracker {
+    /**
+   * @param {Array<Actor>} actors
+   */
+  constructor(actors = []) {
+      this.actors = actors;
+  }
+
+  static load() {
+    const tokenActors = CityHelpers.getVisibleActiveSceneTokenActors().filter( x => x.data.type == "threat" || x.data.type == "extra" || x.data.type == "character");
+    
+    const actors = tokenActors.map( x=> {
+        return {
+            name: x.getDisplayedName(),
+            actor: x,
+            id: x.id,
+            type: x.data.type,
+            statuses: x.items.filter(x => x.type == "status")
+        };
+    });
+
+    return new StatusTracker(actors);
+  }
+
+  async newStatus(indexActor) {
+    const actor = this.actors[indexActor].actor;
+
+    const obj = await actor.createNewStatus("Unnamed Status")
+		const status = await actor.getStatus(obj.id);
+		const updateObj = await CityHelpers.itemDialog(status);
+		if (updateObj) {
+			CityHelpers.modificationLog(actor, "Created", updateObj, `tier  ${updateObj.data.data.tier}`);
+		} else {
+			await owner.deleteStatus(obj.id);
+		}
+  }
+
+  async deleteStatus(indexActor, indexStatus) {
+    const actor = this.actors[indexActor].actor;
+    const statusId = this.actors[indexActor].statuses[indexStatus].id;
+
+    await actor.deleteStatus(statusId);
+  }
+
+  async increaseStatus(indexActor, indexStatus) {
+    const actor = this.actors[indexActor].actor;
+    const statusId = this.actors[indexActor].statuses[indexStatus].id;
+
+    const status = await actor.getStatus(statusId);
+
+    const {data: {name, data: {tier, pips}}} = status;
+		let ret = null;
+		if (ret = await this._statusAddSubDialog(status, game.i18n.localize("CityOfMistTracker.trackerwindow.status.addto"))) {
+			const {name: newname, tier: amt} = ret;
+			console.log(`${name} : ${tier}`);
+			await status.addStatus(amt, newname);
+		}
+  }
+
+  async decreaseStatus(indexActor, indexStatus) {
+    const actor = this.actors[indexActor].actor;
+    const statusId = this.actors[indexActor].statuses[indexStatus].id;
+    
+    const status = await actor.getStatus(statusId);
+
+    const {data: {name, data: {tier, pips}}} = status;
+		let ret = null;
+		if (ret = await this._statusAddSubDialog(status, game.i18n.localize("CityOfMistTracker.trackerwindow.status.subtract"))) {
+			const {name: newname, tier: amt} = ret;
+			console.log(`${name} : ${tier}`);
+			const revised_status = await status.subtractStatus(amt, newname);
+			if (revised_status.data.data.tier <= 0)
+				actor.deleteStatus(revised_status.id);
+		}
+  }
+
+  /* Needs to be moved into CityHelpers */
+  async _statusAddSubDialog(status, title) {
+    const templateData = {status: status.data, data: status.data.data};
+    const html = await renderTemplate("systems/city-of-mist/templates/dialogs/status-addition-dialog.html", templateData);
+    return new Promise ( (conf, reject) => {
+      const options ={};
+      const returnfn = function (html, tier) {
+        conf( {
+          name: $(html).find(".status-name-input").val(),
+          tier
+        });
+      }
+      const dialog = new Dialog({
+        title:`${title}`,
+        content: html,
+        buttons: {
+          one: {
+            label: "1",
+            callback: (html) => returnfn(html, 1)
+          },
+          two: {
+            label: "2",
+            callback: (html) => returnfn(html, 2)
+          },
+          three: {
+            label: "3",
+            callback: (html) => returnfn(html, 3)
+          },
+          four: {
+            label: "4",
+            callback: (html) => returnfn(html, 4)
+          },
+          five: {
+            label: "5",
+            callback: (html) => returnfn(html, 5)
+          },
+          six: {
+            label: "6",
+            callback: (html) => returnfn(html, 6)
+          },
+          cancel: {
+            label: "Cancel",
+            callback: () => conf(null)
+          }
+        },
+        default: "cancel"
+      }, options);
+      dialog.render(true);
+    });
+  }
+}

--- a/module/city-status-tracker/status-tracker.js
+++ b/module/city-status-tracker/status-tracker.js
@@ -17,7 +17,8 @@ export class StatusTracker {
             actor: x,
             id: x.id,
             type: x.data.type,
-            statuses: x.items.filter(x => x.type == "status")
+            statuses: x.getStatuses(),
+            tags: x.getStoryTags()
         };
     });
 
@@ -74,6 +75,26 @@ export class StatusTracker {
 			if (revised_status.data.data.tier <= 0)
 				actor.deleteStatus(revised_status.id);
 		}
+  }
+
+  async newTag(indexActor) {
+    const actor = this.actors[indexActor].actor;
+
+    const obj = await actor.createStoryTag("Unnamed Tag")
+		const tag = await actor.getTag(obj.id);
+		const updateObj = await CityHelpers.itemDialog(tag);
+		if (updateObj) {
+			CityHelpers.modificationLog(actor, "Created", updateObj, `tier  ${updateObj.data.data.tier}`);
+		} else {
+			await owner.deleteTag(obj.id);
+		}
+  }
+
+  async deleteTag(indexActor, indexTag) {
+    const actor = this.actors[indexActor].actor;
+    const tagId = this.actors[indexActor].tags[indexTag].id;
+
+    await actor.deleteTag(tagId);
   }
 
   /* Needs to be moved into CityHelpers */

--- a/module/city.js
+++ b/module/city.js
@@ -18,6 +18,7 @@ import { CityThreatSheet } from "./city-threat-sheet.js";
 import { CityCharacterSheet } from "./city-character-sheet.js";
 import { registerSystemSettings } from "./settings.js";
 import { CityStoryTagContainerSheet } from "./city-story-tag-container-sheet.js";
+import { StatusTrackerWindow } from "./city-status-tracker/city-status-tracker.js";
 
 //Fix for electron browser lacking replaceAll method
 if (String.prototype.replaceAll == undefined) {
@@ -306,4 +307,26 @@ Hooks.once("init", async function() {
 			})
 		).flat();
 	});
+});
+
+/* City of Mist Status Tracker */
+Hooks.on("renderJournalDirectory", async (_app, html, _data) => {
+	window.statusTrackerWindow = new StatusTrackerWindow();
+});
+
+Hooks.on("getSceneControlButtons", function(controls) {
+	let tileControls = controls.find(x => x.name === "token");
+	tileControls.tools.push({
+		icon: "fas fa-medkit",
+		name: "city-of-mist-status-tracker",
+		title: game.i18n.localize("CityOfMistTracker.trackerwindow.title"),
+		button: true,
+		onClick: () => window.statusTrackerWindow.render(true)
+	});
+});
+  
+Hooks.on("renderApplication", function(control) {
+	if (window.statusTrackerWindow) {
+		window.statusTrackerWindow.render(false);
+	}
 });

--- a/module/city.js
+++ b/module/city.js
@@ -316,13 +316,15 @@ Hooks.on("renderJournalDirectory", async (_app, html, _data) => {
 
 Hooks.on("getSceneControlButtons", function(controls) {
 	let tileControls = controls.find(x => x.name === "token");
-	tileControls.tools.push({
-		icon: "fas fa-medkit",
-		name: "city-of-mist-status-tracker",
-		title: game.i18n.localize("CityOfMistTracker.trackerwindow.title"),
-		button: true,
-		onClick: () => window.statusTrackerWindow.render(true)
-	});
+	if (game.user.isGM){
+		tileControls.tools.push({
+			icon: "fas fa-medkit",
+			name: "city-of-mist-status-tracker",
+			title: game.i18n.localize("CityOfMistTracker.trackerwindow.title"),
+			button: true,
+			onClick: () => window.statusTrackerWindow.render(true)
+		});
+	}
 });
   
 Hooks.on("renderApplication", function(control) {

--- a/system.json
+++ b/system.json
@@ -15,7 +15,8 @@
   ],
   "styles": [
     "styles/city.css",
-	 "module/token-tooltip/tooltip.css"
+	 "module/token-tooltip/tooltip.css",
+   "module/city-status-tracker/city-status-tracker.css"
   ],
   "languages": [
     {


### PR DESCRIPTION
Hello,

I've add a **Status & Tag Tracker** to the system. This allows the GM to keep track of all statuses and tags on actors on the activated scene (in the same way as the status and tag part of the PC sheet). With it, the GM can create, delete and edit statuses and tags on the fly without opening the character sheet of each actor.

![image](https://user-images.githubusercontent.com/76685550/146539942-92151fcf-4bba-4ddc-a592-e3619bb71f80.png)
