### PR TITLE
Add system compat and subtype to theme item props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/src/city-of-mist/module/city-actor.ts
+++ b/src/city-of-mist/module/city-actor.ts
@@ -569,8 +569,18 @@ export class CityActor extends Actor<typeof ACTORMODELS, CityItem, ActiveEffect<
 		const nascent = !this.isNewCharacter();
 		const unspent_upgrades = nascent ? 1 : 3;
 		const themebook_name = themebook.name;
+		const subtype = themebook.system.subtype;
+		const system_compatiblity = themebook.system.system_compatiblity;
+		const locale_name = themebook.system.locale_name
 		const system : Partial<Theme["system"]>= {
-			themebook_id: themebook.id, themebook_name, unspent_upgrades, nascent, isExtra
+			themebook_id: themebook.id,
+			themebook_name,
+			unspent_upgrades,
+			nascent,
+			isExtra,
+			subtype,
+			system_compatiblity,
+			locale_name
 		};
 		const obj = {
 			name, type: "theme", system	};

--- a/src/city-of-mist/module/city-sheet.ts
+++ b/src/city-of-mist/module/city-sheet.ts
@@ -153,7 +153,7 @@ export class CitySheet extends ActorSheet<CityActor> {
 
 	async confirmBox(title: string, text: string, options: Record<string, unknown> = {}) {
 		const loc_title = localizeS(title);
-		return await HTMLTools.confirmBox(loc_title as string, text, options);
+		return await HTMLTools.confirmBox(loc_title.toString(), text, options);
 	}
 
 	themeDeleteChoicePrompt(themename: string) {

--- a/src/city-of-mist/module/datamodel/item-types.ts
+++ b/src/city-of-mist/module/datamodel/item-types.ts
@@ -106,7 +106,7 @@ class Themebook extends DataModel {
 			improvements: new obj<ThemebookImprovementData>(),
 			motivation: new txt<Motivation>({initial: "mystery"}),
 			fade_type: new txt<FadeType >({initial: "default"}),
-			system_compatiblity: new txt<System | "any">({initial: "city-of-mist"})
+			system_compatiblity: new txt<System | "any">({initial: "city-of-mist"}),
 		}
 	}
 }
@@ -125,6 +125,7 @@ class Themekit extends DataModel {
 			motivation: new txt<Motivation>({initial: "mystery"}),
 			fade_type: new txt<FadeType>({initial: "default"}),
 			subtype: new txt<ThemeType>( {initial: "Logos"}),
+			system_compatiblity: new txt<System | "any">({initial: "city-of-mist"}),
 		}
 	}
 }
@@ -182,6 +183,8 @@ class Theme extends DataModel {
 			img: new txt(),
 			nascent: new bool({initial: false}),
 			isExtra: new bool({initial: false}),
+			system_compatiblity: new txt<System | "any">({initial: "city-of-mist"}),
+			subtype: new txt<ThemeType>( {initial: "Logos"}),
 		}
 	}
 }


### PR DESCRIPTION
- Add system compat, subtype and locale key to theme item props. This is necessary to remove [hardcoded config in mist-hud](https://github.com/mordachai/mist-hud/blob/main/scripts/mh-theme-config.js#L4-L50) module, and instead derive the essence and stuff from item itself. It also would enable support of drag-and-drop'd themes in mist-hud later.
- Fix bug with modal window by calling title.toString explicitly (it was an object of `SafeString`)