### PR TITLE
Fix: spectrums not visible

### DIFF
--- a/src/city-of-mist/templates/parts/threat-sheet-header.html
+++ b/src/city-of-mist/templates/parts/threat-sheet-header.html
@@ -15,19 +15,8 @@
 <div class="header-row">
 	<input type="text" class="borderless short-description" name="system.short_description" value="{{actor.system.short_description}}" placeholder="{{localize 'CityOfMist.terms.short_desc' }} " title="{{localize 'CityOfMist.terms.short_desc' }} " {{#if actor.system.locked}} disabled {{/if}}>
 </div>
+
 {{#if actor.system.locked}}
-<div class="header-row">
-	<div class="spectrum-list">
-		<b>
-			{{localize 'CityOfMist.terms.spectrums' }}
-		</b>
-		{{#each actor.spectrums as |spectrum id|}}
-		<div class="spectrum-short-label">
-			{{spectrum.name}} {{spectrumConvert spectrum.system.maxTier}}
-		</div>
-		{{/each}}
-	</div>
-</div>
 <div class="header-row">
 	<label class="dialog-label" for="name">
 		{{#if usingCollective}}
@@ -44,8 +33,6 @@
 	<input type="radio" name="system.collectiveSize" value=5 {{#if (eq 5 actor.system.collectiveSize)}} checked {{/if}}  >5 </input>
 	<input type="radio" name="system.collectiveSize" value=6 {{#if (eq 6 actor.system.collectiveSize)}} checked {{/if}}  >6 </input>
 </div>
-
-
 {{/if}}
 
 

--- a/src/city-of-mist/templates/threat-sheet.html
+++ b/src/city-of-mist/templates/threat-sheet.html
@@ -26,14 +26,14 @@
 		</div>
 		</div>
 	</header>
-	{{#if (and (not actor.system.locked) (isGM))}}
+	{{#if (isGM)}}
 	<section class="threat-spectrums">
 		<div class="spectrum-section-label">
 			{{localize 'CityOfMist.terms.spectrums' }}
 			{{#if (not actor.system.locked)}}
 			<a class="create-spectrum" data-actor-id={{actor.id}}> <i class="fas fa-plus-square"></i></a>
+			{{/if}}
 		</div>
-		{{/if}}
 		<div class="spectrum-list">
 			{{#each actor.my_spectrums as |spectrum id|}}
 			{{> "systems/city-of-mist/templates/parts/spectrum-display.html" spectrum=spectrum owner=../actor locked=../actor.system.locked sheetowner=actor }}


### PR DESCRIPTION
I removed duplicated code part in `src/city-of-mist/templates/parts/threat-sheet-header.html` and allow always show spectrums and label for GM